### PR TITLE
add hash128 to get a single python long

### DIFF
--- a/mmh3module.cpp
+++ b/mmh3module.cpp
@@ -72,6 +72,33 @@ mmh3_hash64(PyObject *self, PyObject *args, PyObject *keywds)
 }
 
 static PyObject *
+mmh3_hash128(PyObject *self, PyObject *args, PyObject *keywds)
+{
+    const char *target_str;
+    int target_str_len;
+    uint32_t seed = 0;
+    uint64_t result[2];
+    char x64arch = 1;
+
+    static char *kwlist[] = {(char *)"key", (char *)"seed",
+      (char *)"x64arch", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "s#|i|B", kwlist,
+        &target_str, &target_str_len, &seed, &x64arch)) {
+        return NULL;
+    }
+
+    if (x64arch == 1) {
+      MurmurHash3_x64_128(target_str, target_str_len, seed, result);
+    } else {
+      MurmurHash3_x86_128(target_str, target_str_len, seed, result);
+    }
+
+    PyObject *retval = _PyLong_FromByteArray((unsigned char *)result, 16, 1, 0);
+    return retval;
+}
+
+static PyObject *
 mmh3_hash_bytes(PyObject *self, PyObject *args, PyObject *keywds)
 {
     const char *target_str;
@@ -112,9 +139,11 @@ static struct module_state _state;
 
 static PyMethodDef Mmh3Methods[] = {
     {"hash", (PyCFunction)mmh3_hash, METH_VARARGS | METH_KEYWORDS,
-        "hash(key[, seed=0]) -> hash value\n Return a 32 bit integer for a string."},
+        "hash(key[, seed=0]) -> hash value\n Return a 32 bit integer."},
     {"hash64", (PyCFunction)mmh3_hash64, METH_VARARGS | METH_KEYWORDS,
         "hash64(key[, seed=0, x64arch=True]) -> (hash value 1, hash value 2)\n Return a tuple of two 64 bit integers for a string. Optimized for the x64 bit architecture when x64arch=True, otherwise for x86."},
+    {"hash128", (PyCFunction)mmh3_hash128, METH_VARARGS | METH_KEYWORDS,
+        "hash128(key[, seed=0]) -> hash value\n Return a 128 bit long integer."},
     {"hash_bytes", (PyCFunction)mmh3_hash_bytes,
       METH_VARARGS | METH_KEYWORDS,
         "hash_bytes(key[, seed=0, x64arch=True]) -> bytes\n Return a 128 bit hash value as bytes for a string. Optimized for the x64 bit architecture when x64arch=True, otherwise for the x86."},


### PR DESCRIPTION
because a tuple of 64bit ints is not as easily usable
