### PR TITLE
Build CPython3.10 wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,29 +14,29 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-10.15]
+        os: [ubuntu-22.04, windows-2022, macOS-11]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Set up QEMU
         if: runner.os == 'Linux'
         uses: docker/setup-qemu-action@v1.0.1
         with:
           platforms: arm64
       - name: Build wheels
-        uses: joerick/cibuildwheel@v1.9.0
+        uses: joerick/cibuildwheel@v2.8.1
         with:
           output-dir: wheelhouse
         env:
-          CIBW_BUILD: '{cp36,cp37,cp38,cp39}-{manylinux_x86_64,manylinux_aarch64,win32,win_amd64,macosx_x86_64} cp39-macosx_arm64'
+          CIBW_BUILD: '{cp38,cp39,cp310}-{manylinux_x86_64,manylinux_aarch64,win32,win_amd64,macosx_x86_64} cp310-macosx_arm64'
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
           CIBW_ARCHS_LINUX: 'auto aarch64'
           CIBW_ARCHS_MACOS: 'auto arm64'
-          CIBW_TEST_REQUIRES: 'pytest numpy==1.19.5'
+          CIBW_TEST_REQUIRES: 'pytest numpy'
           CIBW_TEST_COMMAND: 'pytest {project}'
           CIBW_TEST_SKIP: '*-macosx_arm64' # Until the day Apple silicon instances are available on GitHub Actions
       - uses: actions/upload-artifact@v2
@@ -44,14 +44,14 @@ jobs:
           path: ./wheelhouse/*.whl
   build_sdist:
     name: Build a source distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Build sdist
         run: python setup.py build sdist
       - uses: actions/upload-artifact@v2
@@ -59,13 +59,13 @@ jobs:
           path: dist/*.tar.gz
   publish:
     name: 'Upload to PyPI/Test PyPI'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [build_wheels, build_sdist]
     steps:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Set up built items
         uses: actions/download-artifact@v2
         with:

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Software Development :: Libraries",
         "Topic :: Utilities",
     ],


### PR DESCRIPTION
Similar to https://github.com/hajimes/mmh3/pull/35, `mmh3` currently does not have 3.10 support. Couldn't build 3.10 wheels from his PR, but did manage to manually build them by bumping pinned `cbuildwheel` module and unpinning numpy.

Think newer release of mmh3 could also drop 3.6 since it reached it's end of life back in December.

I did not test upload to PyPI. 