### PR TITLE
fix 'mmh3_hash' and 'mmh3_hash_from_buffer' result handling on 32bit …

### DIFF
--- a/mmh3module.cpp
+++ b/mmh3module.cpp
@@ -40,7 +40,9 @@ mmh3_hash(PyObject *self, PyObject *args, PyObject *keywds)
       (char *)"signed", NULL};
       
 #ifndef _MSC_VER
+#if __LONG_WIDTH__ == 64
   static uint64_t mask[] = {0x0ffffffff, 0xffffffffffffffff};
+#endif
 #endif
 
     if (!PyArg_ParseTupleAndKeywords(args, keywds, "s#|IB", kwlist,
@@ -60,8 +62,17 @@ mmh3_hash(PyObject *self, PyObject *args, PyObject *keywds)
   }
 #else  
   /* for standard envs */
+#if __LONG_WIDTH__ == 64
   long_result = result[0] & mask[is_signed];
   return PyLong_FromLong(long_result);
+#else
+  long_result = result[0];
+  if (is_signed == 1) {
+    return PyLong_FromLong(long_result);
+  } else {
+    return PyLong_FromUnsignedLong(long_result);
+  }
+#endif
 #endif
 }
 
@@ -78,7 +89,9 @@ mmh3_hash_from_buffer(PyObject *self, PyObject *args, PyObject *keywds)
       (char *)"signed", NULL};
 
 #ifndef _MSC_VER
+#if __LONG_WIDTH__ == 64
     static uint64_t mask[] = {0x0ffffffff, 0xffffffffffffffff};
+#endif
 #endif
 
     if (!PyArg_ParseTupleAndKeywords(args, keywds, "s*|IB", kwlist,
@@ -98,8 +111,17 @@ mmh3_hash_from_buffer(PyObject *self, PyObject *args, PyObject *keywds)
     }
 #else
     /* for standard envs */
+  #if __LONG_WIDTH__ == 64
     long_result = result[0] & mask[is_signed];
     return PyLong_FromLong(long_result);
+  #else
+    long_result = result[0];
+    if (is_signed == 1) {
+      return PyLong_FromLong(long_result);
+    } else {
+      return PyLong_FromUnsignedLong(long_result);
+    }
+  #endif
 #endif
 }
 


### PR DESCRIPTION
linux: i586, armh

- added conditional 'mmh3_hash'	and 'mmh3_hash_from_buffer' functions result handling depending on target platform architecture

Current 32bit hash functions result conversion method fails on 32 bit architectures (confirmed on **i586** and **armh** platforms).

```
__________________________________________ test_hash_unsigned __________________________________________

    def test_hash_unsigned():
>       assert mmh3.hash("foo", signed=False) == 4138058784
E       AssertionError: assert -156908512 == 4138058784
E        +  where -156908512 = <built-in function hash>('foo', signed=False)
E        +    where <built-in function hash> = mmh3.hash

test_mmh3.py:74: AssertionError
________________________________________ test_hash_from_buffer _________________________________________

    def test_hash_from_buffer():
        mview = memoryview("foo".encode("utf8"))
        assert mmh3.hash_from_buffer(mview) == -156908512
>       assert mmh3.hash_from_buffer(mview, signed=False) == 4138058784
E       assert -156908512 == 4138058784
E        +  where -156908512 = <built-in function hash_from_buffer>(<memory at 0xf71d82c8>, signed=False)
E        +    where <built-in function hash_from_buffer> = mmh3.hash_from_buffer

test_mmh3.py:181: AssertionError
======================================= short test summary info ========================================
FAILED test_mmh3.py::test_hash_unsigned - AssertionError: assert -156908512 == 4138058784
FAILED test_mmh3.py::test_hash_from_buffer - assert -156908512 == 4138058784
```

On 64 bit architectures (confirmed on **x86_64**, **aarch64** and **ppc64le** platforms) applied conversion methods works fine and all tests passed.

Preprocessor conditions added to modify code when built on 32 bit platforms using predefined `__LONG_WIDTH__` symbol available with GCC and Clang compilers.r conditions to modify code when built on 32 bit platforms using predefined `__LONG_WIDTH__` symbol available with GCC and Clang compilers.