### PR TITLE
Improve basic hash by METH_FASTCALL

### DIFF
--- a/.github/workflows/benchmark-base-hash.yml
+++ b/.github/workflows/benchmark-base-hash.yml
@@ -2,10 +2,7 @@
 name: Benchmark Base Hash
 
 on:
-  push:
-    branches:
-      - master
-      - feature/**
+  workflow_dispatch:
 
 permissions: {}
 

--- a/.github/workflows/benchmark-base-hash.yml
+++ b/.github/workflows/benchmark-base-hash.yml
@@ -1,0 +1,91 @@
+---
+name: Benchmark Base Hash
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  benchmark:
+    permissions:
+      contents: read
+      packages: read
+    runs-on: ubuntu-22.04
+    env:
+      BENCHMARK_MAX_SIZE: 65536
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install .
+          pip install ".[benchmark]"
+      - name: Tune the system for benchmarking
+        run: |
+          echo "Running \"lscpu -a -e\"..."
+          lscpu -a -e
+
+          echo -n "Checking randomize_va_space: "
+          cat /proc/sys/kernel/randomize_va_space
+          echo "randomize_va_space should be 2, meaning ASLR is fully enabled."
+
+          systemctl status irqbalance
+          echo "Stopping irqbalance..."
+          sudo systemctl stop irqbalance
+
+          echo -n "Checking default_smp_affinity: "
+          cat /proc/irq/default_smp_affinity
+          echo 3 | sudo tee /proc/irq/default_smp_affinity > /dev/null
+          echo -n "Updated default_smp_affinity to: "
+          cat /proc/irq/default_smp_affinity
+
+          echo -n "Checking perf_event_max_sample_rate: "
+          cat /proc/sys/kernel/perf_event_max_sample_rate
+          echo 1 | sudo tee /proc/sys/kernel/perf_event_max_sample_rate > /dev/null
+          echo -n "Updated perf_event_max_sample_rate to: "
+          cat /proc/sys/kernel/perf_event_max_sample_rate
+      - name: Benchmark hash functions
+        run: |
+          mkdir var
+          taskset -c 2,3 python benchmark/benchmark.py \
+            -o var/mmh3_base_hash_500.json \
+            --test-hash mmh3_base_hash \
+            --test-buffer-size-max "$BENCHMARK_MAX_SIZE"
+          taskset -c 2,3 python benchmark/benchmark.py \
+            -o var/mmh3_32_500.json \
+            --test-hash mmh3_32 \
+            --test-buffer-size-max "$BENCHMARK_MAX_SIZE"
+          pip uninstall -y mmh3
+          pip install mmh3==4.1.0
+          taskset -c 2,3 python benchmark/benchmark.py \
+            -o var/mmh3_base_hash_410.json \
+            --test-hash mmh3_base_hash \
+            --test-buffer-size-max "$BENCHMARK_MAX_SIZE"
+      - name: Reset the system from benchmarking
+        run: |
+          echo -n "Checking perf_event_max_sample_rate: "
+          cat /proc/sys/kernel/perf_event_max_sample_rate
+          echo 100000 | sudo tee /proc/sys/kernel/perf_event_max_sample_rate > /dev/null
+          echo -n "Updated perf_event_max_sample_rate to: "
+          cat /proc/sys/kernel/perf_event_max_sample_rate
+
+          echo -n "Checking default_smp_affinity: "
+          cat /proc/irq/default_smp_affinity
+          echo f | sudo tee /proc/irq/default_smp_affinity > /dev/null
+          echo -n "Updated default_smp_affinity to: "
+          cat /proc/irq/default_smp_affinity
+
+          echo "Restarting irqbalance..."
+          sudo systemctl restart irqbalance
+          systemctl status irqbalance
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: var

--- a/.github/workflows/benchmark-base-hash.yml
+++ b/.github/workflows/benchmark-base-hash.yml
@@ -2,7 +2,10 @@
 name: Benchmark Base Hash
 
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - feature/**
 
 permissions: {}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,16 @@ since version 3.0.0.
 ### Added
 
 - Add support for Python 3.13.
+- Improve the performance of the `hash()` function with
+  [METH_FASTCALL](https://docs.python.org/3/c-api/structures.html#c.METH_FASTCALL),
+  reducing the overhead of function calls. For data sizes between 1–2 KB
+  (e.g., 48x48 favicons), performance is 10%–20% faster. For smaller data
+  (~500 bytes, like 16x16 favicons), performance increases by approximately 30%.
 - Add `digest` functions that support the new buffer protocol
   ([PEP 688](https://peps.python.org/pep-0688/)) as input
   ([#75](https://github.com/hajimes/mmh3/pull/75)).
-  These functions are implemented with
-  [METH_FASTCALL](https://docs.python.org/3/c-api/structures.html#c.METH_FASTCALL),
-  offering improved performance over legacy functions
-  ([#84](https://github.com/hajimes/mmh3/pull/84)).
+  These functions are implemented with `METH_FASTCALL` too, offering improved
+  performance ([#84](https://github.com/hajimes/mmh3/pull/84)).
 - Slightly improve the performance of the `hash_bytes()` function.
 - Add Read the Docs documentation
   ([#54](https://github.com/hajimes/mmh3/issues/54)).

--- a/README.md
+++ b/README.md
@@ -136,13 +136,16 @@ complete changelog.
 #### Added
 
 - Add support for Python 3.13.
+- Improve the performance of the `hash()` function with
+  [METH_FASTCALL](https://docs.python.org/3/c-api/structures.html#c.METH_FASTCALL),
+  reducing the overhead of function calls. For data sizes between 1–2 KB
+  (e.g., 48x48 favicons), performance is 10%–20% faster. For smaller data
+  (~500 bytes, like 16x16 favicons), performance increases by approximately 30%.
 - Add `digest` functions that support the new buffer protocol
   ([PEP 688](https://peps.python.org/pep-0688/)) as input
   ([#75](https://github.com/hajimes/mmh3/pull/75)).
-  These functions are implemented with
-  [METH_FASTCALL](https://docs.python.org/3/c-api/structures.html#c.METH_FASTCALL),
-  offering improved performance over legacy functions
-  ([#84](https://github.com/hajimes/mmh3/pull/84)).
+  These functions are implemented with `METH_FASTCALL` too, offering improved
+  performance ([#84](https://github.com/hajimes/mmh3/pull/84)).
 - Slightly improve the performance of the `hash_bytes()` function.
 - Add Read the Docs documentation
   ([#54](https://github.com/hajimes/mmh3/issues/54)).

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -223,9 +223,20 @@ def add_cmdline_args(cmd: list, args) -> None:
     cmd.extend(("--test-buffer-size-max", str(args.test_buffer_size_max)))
 
 
+# "if hasattr" is used to check for the existence of the function in the
+# module, to compare the performance of the current implementation with the
+# old one (version 4.1.0), which does not implement the new functions.
+# These conditions should be removed in the future.
 HASHES = {
-    "mmh3_32": mmh3.mmh3_32_digest,
-    "mmh3_128": mmh3.mmh3_x64_128_digest,
+    "mmh3_base_hash": mmh3.hash,
+    "mmh3_32": (
+        mmh3.mmh3_32_digest if hasattr(mmh3, "mmh3_32_digest") else mmh3.hash_bytes
+    ),
+    "mmh3_128": (
+        mmh3.mmh3_x64_128_digest
+        if hasattr(mmh3, "mmh3_x64_128_digest")
+        else mmh3.hash128
+    ),
     "xxh_32": xxhash.xxh32_digest,
     "xxh_64": xxhash.xxh64_digest,
     "xxh3_64": xxhash.xxh3_64_digest,
@@ -257,7 +268,7 @@ if __name__ == "__main__":
     runner.argparser.add_argument(
         "--test-type",
         type=str,
-        help="Type of benchmarking to perform",
+        help="Type of benchmarking to perform (experimental)",
         choices=BENCHMARKING_TYPES.keys(),
         default="random",
     )

--- a/benchmark/plot_graph.py
+++ b/benchmark/plot_graph.py
@@ -46,6 +46,7 @@ def ordered_intersection(list1: list[T], list2: list[T]) -> list[T]:
 
 
 DIGEST_SIZES = {
+    "mmh3_base_hash": mmh3.mmh3_32().digest_size,
     "mmh3_32": mmh3.mmh3_32().digest_size,
     "mmh3_128": mmh3.mmh3_x64_128().digest_size,
     "xxh_32": xxhash.xxh32().digest_size,

--- a/src/mmh3/mmh3module.c
+++ b/src/mmh3/mmh3module.c
@@ -155,7 +155,7 @@ PyDoc_STRVAR(
     ".. versionchanged:: 5.0.0\n"
     "    The ``seed`` argument is now strictly checked for valid range.\n"
     "    The type of the ``signed`` argument has been changed from\n"
-    "    ``bool`` to ``Any``.\n");
+    "    ``bool`` to ``Any``. Performance improvements have been made.\n");
 
 static PyObject *
 mmh3_hash(PyObject *self, PyObject *const *args, Py_ssize_t nargs,

--- a/tests/test_invalid_inputs.py
+++ b/tests/test_invalid_inputs.py
@@ -18,6 +18,9 @@ def test_hash_raises_typeerror() -> None:
         mmh3.hash(b"hello, world", seed="42")
     with pytest.raises(TypeError):
         mmh3.hash([1, 2, 3], 42)
+    # pylint: disable=redundant-keyword-arg
+    with pytest.raises(TypeError):
+        mmh3.hash(b"hello, world", key=b"42")
 
 
 @no_type_check


### PR DESCRIPTION
Improve the performance of the `hash()` function with [METH_FASTCALL](https://docs.python.org/3/c-api/structures.html#c.METH_FASTCALL), reducing the overhead of function calls. For data sizes between 1–2 KB (e.g., 48x48 favicons), performance is 10%–20% faster. For smaller data (~500 bytes, like 16x16 favicons), performance increases by approximately 30%.

Note that other legacy functions such as `hash128()` and `hash64()` are not yet updated in this PR.