### PR TITLE
Fix issue with not building from sdist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,19 +44,11 @@ jobs:
         run: python -m pytest
       - name: Test type hints with mypy
         run: mypy --strict tests
-      - name: Test building from the source distribution (Linux/macOS)
-        if: runner.os != "Windows"
+      - name: Test building from the source distribution
+        shell: bash
         run: |
           pip uninstall -y mmh3
           python -m build --sdist
           python -m pip install dist/*.tar.gz
-          python -m pytest
-          mypy --strict tests
-      - name: Test building from the source distribution (Windows)
-        if: runner.os == "Windows"
-        run: |
-          pip uninstall -y mmh3
-          python -m build --sdist
-          for %i in (dist\*.tar.gz) do python -m pip install %i
           python -m pytest
           mypy --strict tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,13 +42,21 @@ jobs:
           pip install ".[test,type]"
       - name: Test with pytest
         run: python -m pytest
-      - name: Check source distribution
+      - name: Test type hints with mypy
+        run: mypy --strict tests
+      - name: Test building from the source distribution (Linux/macOS)
+        if: runner.os != "Windows"
         run: |
           pip uninstall -y mmh3
           python -m build --sdist
-          if [[ "${{ matrix.os }}" == "windows-2022" ]]; then
-            for %i in (dist\*.tar.gz) do python -m pip install %i
-          else
-            python -m pip install dist/*.tar.gz
-          fi
+          python -m pip install dist/*.tar.gz
           python -m pytest
+          mypy --strict tests
+      - name: Test building from the source distribution (Windows)
+        if: runner.os == "Windows"
+        run: |
+          pip uninstall -y mmh3
+          python -m build --sdist
+          for %i in (dist\*.tar.gz) do python -m pip install %i
+          python -m pytest
+          mypy --strict tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,10 +36,16 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install --upgrade pip
+          python -m pip install --upgrade pip
+          pip install setuptools build
           pip install .
           pip install ".[test,type]"
       - name: Test with pytest
         run: python -m pytest
-      - name: Test type hints with mypy
-        run: mypy --strict tests
+      - name: Check source distribution
+        run: |
+          pip uninstall -y mmh3
+          python -m build --sdist
+          python -m pip install dist/*.tar.gz
+          python -m pytest
+  

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,4 +48,3 @@ jobs:
           python -m build --sdist
           python -m pip install dist/*.tar.gz
           python -m pytest
-  

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,5 +46,9 @@ jobs:
         run: |
           pip uninstall -y mmh3
           python -m build --sdist
-          python -m pip install dist/*.tar.gz
+          if [[ "${{ matrix.os }}" == "windows-2022" ]]; then
+            for %i in (dist\*.tar.gz) do python -m pip install %i
+          else
+            python -m pip install dist/*.tar.gz
+          fi
           python -m pytest

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -81,6 +81,8 @@ jobs:
       - name: Test building from the source distribution
         shell: bash
         run: |
+          pip install ".[test,type]"
+          pip uninstall -y mmh3
           python -m pip install dist/*.tar.gz
           python -m pytest
           mypy --strict tests

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -78,6 +78,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install setuptools build
           python -m build --sdist
+      - name: Test building from the source distribution
+        shell: bash
+        run: |
+          python -m pip install dist/*.tar.gz
+          python -m pytest
+          mypy --strict tests
       - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ This project has adhered to
 [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html)
 since version 3.0.0.
 
+## [5.0.1] - 2024-09-22
+
+### Fixed
+
+- Fix the issue that the package cannot be built from the source distribution
+  ([#90](https://github.com/hajimes/mmh3/issues/90)).
+
 ## [5.0.0] - 2024-09-18
 
 ### Added
@@ -260,6 +267,7 @@ only.
   [Softpedia collected mmh3 1.0 on April 27, 2011](https://web.archive.org/web/20110430172027/https://linux.softpedia.com/get/Programming/Libraries/mmh3-68314.shtml),
   it must have been uploaded to PyPI on or slightly before this date.
 
+[5.0.1]: https://github.com/hajimes/mmh3/compare/v5.0.0...v5.0.1
 [5.0.0]: https://github.com/hajimes/mmh3/compare/v4.1.0...v5.0.0
 [4.1.0]: https://github.com/hajimes/mmh3/compare/v4.0.1...v4.1.0
 [4.0.1]: https://github.com/hajimes/mmh3/compare/v4.0.0...v4.0.1

--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ in the API Reference for more information.
 See [Changelog](https://mmh3.readthedocs.io/en/latest/changelog.html) for the
 complete changelog.
 
+### [5.0.1] - 2024-09-22
+
+#### Fixed
+
+- Fix the issue that the package cannot be built from the source distribution
+  ([#90](https://github.com/hajimes/mmh3/issues/90)).
+
 ### [5.0.0] - 2024-09-18
 
 #### Added
@@ -240,5 +247,6 @@ is useful for OSINT and cybersecurity activities.
 - <https://github.com/ifduyue/python-xxhash>: Python bindings for xxHash (Yue
   Du)
 
+[5.0.1]: https://github.com/hajimes/mmh3/compare/v5.0.0...v5.0.1
 [5.0.0]: https://github.com/hajimes/mmh3/compare/v4.1.0...v5.0.0
 [4.1.0]: https://github.com/hajimes/mmh3/compare/v4.0.1...v4.1.0

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 [![PyPi Version](https://img.shields.io/pypi/v/mmh3.svg?style=flat-square&logo=pypi&logoColor=white)](https://pypi.org/project/mmh3/)
 [![Python Versions](https://img.shields.io/pypi/pyversions/mmh3.svg)](https://pypi.org/project/mmh3/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/license/mit/)
-[![Total Downloads](https://static.pepy.tech/badge/mmh3)](https://pepy.tech/project/mmh3?versions=*&versions=4.*&versions=3.*&versions=2.*)
-[![Recent Downloads](https://static.pepy.tech/badge/mmh3/month)](https://pepy.tech/project/mmh3?versions=*&versions=4.*&versions=3.*&versions=2.*)
+[![Total Downloads](https://static.pepy.tech/badge/mmh3)](https://www.pepy.tech/projects/mmh3?versions=*&versions=5.*&versions=4.*&versions=3.*&versions=2.*)
+[![Recent Downloads](https://static.pepy.tech/badge/mmh3/month)](https://www.pepy.tech/projects/mmh3?versions=*&versions=5.*&versions=4.*&versions=3.*&versions=2.*)
 
 `mmh3` is a Python extension for
 [MurmurHash (MurmurHash3)](https://en.wikipedia.org/wiki/MurmurHash), a set of

--- a/README.md
+++ b/README.md
@@ -166,8 +166,9 @@ By default, `mmh3` returns **signed** values for the 32-bit and 64-bit versions
 and **unsigned** values for `hash128` due to historical reasons. To get the
 desired result, use the `signed` keyword argument.
 
-Starting from version 4.0.0, `mmh3` returns the same values on big-endian
-platforms as it does on little-endian ones, whereas the original C++ library is
+Starting from version 4.0.0, **`mmh3` is endian-neutral**, meaning that its
+hash functions return the same values on big-endian platforms as they do on
+little-endian ones. In contrast, the original C++ library by Appleby is
 endian-sensitive. If you need results that comply with the original library on
 big-endian systems, please use version 3.\*.
 

--- a/docs/CONTRIBUTORS.md
+++ b/docs/CONTRIBUTORS.md
@@ -49,6 +49,8 @@ bug reports, feature suggestions, and other contributions:
   [#25](https://github.com/hajimes/mmh3/issues/25).
 - [Jacques Dark](https://github.com/jqdark),
   [#12](https://github.com/hajimes/mmh3/issues/12).
+- [Matej Spiller Muys](https://github.com/matejsp),
+  [#90](https://github.com/hajimes/mmh3/issues/90).
 - [Niklas Semmler](https://github.com/niklassemmler),
   [#7](https://github.com/hajimes/mmh3/issues/7).
 - [Ryan](https://github.com/ryanfwy),

--- a/docs/api.md
+++ b/docs/api.md
@@ -25,6 +25,13 @@ functions particularly useful:
   a `bytes` object, similar to the `hashlib` module in the Python Standard
   Library. It performs faster than the 32-bit variant on 64-bit machines.
 
+Note that **`mmh3` is endian-neutral**, while the original C++ library is
+endian-sensitive (see also
+[Known Issues](https://github.com/hajimes/mmh3#known-issues)).
+This feature of `mmh3` is essential when portability across different
+architectures is required, such as when calculating hash footprints for web
+services.
+
 ## Basic Hash Functions
 
 The following functions are used to hash immutable types, specifically

--- a/foo.sh
+++ b/foo.sh
@@ -1,5 +1,0 @@
-          if [[ "aas" == "windows-2022" ]]; then
-            for %i in (dist\*.tar.gz) do python -m pip install %i
-          else
-            python -m pip install dist/*.tar.gz
-          fi

--- a/foo.sh
+++ b/foo.sh
@@ -1,0 +1,5 @@
+          if [[ "aas" == "windows-2022" ]]; then
+            for %i in (dist\*.tar.gz) do python -m pip install %i
+          else
+            python -m pip install dist/*.tar.gz
+          fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,11 +75,8 @@ ext-modules = [
   {name = "mmh3", sources = ["./src/mmh3/mmh3module.c", "./src/mmh3/murmurhash3.c"]}
 ]
 
-[tool.setuptools.packages.find]
-where = ["src/mmh3"]
-
 [tool.setuptools.package-data]
-mmh3 = ["murmurhash3.h", "hashlib.h"]
+mmh3 = ["*.h"]
 
 [tool.pylint]
 ignore-paths = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,20 +65,14 @@ Repository = "https://github.com/hajimes/mmh3"
 Changelog = "https://github.com/hajimes/mmh3/blob/master/CHANGELOG.md"
 "Bug Tracker" = "https://github.com/hajimes/mmh3/issues"
 
-[tool.setuptools]
-ext-modules = [
-  {name = "mmh3", sources=["./src/mmh3/mmh3module.c", "./src/mmh3/murmurhash3.c"]}
-]
-
-[tool.setuptools.package-data]
-mmh3 = [
-  "./src/mmh3/murmurhash3.h",
-  "./src/mmh3/hashlib.h"
-]
-
 [tool.isort]
 profile = "black"
 src_paths = ["src/mmh3/__init__.pyi", "util", "tests", "benchmark", "docs"]
+
+[tool.setuptools]
+ext-modules = [
+  {name = "mmh3", sources = ["./src/mmh3/mmh3module.c", "./src/mmh3/murmurhash3.c"], include-dirs = ["./src/mmh3"]}
+]
 
 [tool.pylint]
 ignore-paths = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,8 +70,9 @@ profile = "black"
 src_paths = ["src/mmh3/__init__.pyi", "util", "tests", "benchmark", "docs"]
 
 [tool.setuptools]
+include-package-data = true
 ext-modules = [
-  {name = "mmh3", sources = ["./src/mmh3/mmh3module.c", "./src/mmh3/murmurhash3.c"], include-dirs = ["./src/mmh3"]}
+  {name = "mmh3", sources = ["./src/mmh3/mmh3module.c", "./src/mmh3/murmurhash3.c"]}
 ]
 
 [tool.pylint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mmh3"
-version = "5.0.0"
+version = "5.0.1-dev"
 description = "Python extension for MurmurHash (MurmurHash3), a set of fast and robust hash functions."
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mmh3"
-version = "5.0.1-dev"
+version = "5.0.1-rc.1"
 description = "Python extension for MurmurHash (MurmurHash3), a set of fast and robust hash functions."
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,12 @@ ext-modules = [
   {name = "mmh3", sources=["./src/mmh3/mmh3module.c", "./src/mmh3/murmurhash3.c"]}
 ]
 
+[tool.setuptools.package-data]
+mmh3 = [
+  "./src/mmh3/murmurhash3.h",
+  "./src/mmh3/hashlib.h"
+]
+
 [tool.isort]
 profile = "black"
 src_paths = ["src/mmh3/__init__.pyi", "util", "tests", "benchmark", "docs"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,12 @@ ext-modules = [
   {name = "mmh3", sources = ["./src/mmh3/mmh3module.c", "./src/mmh3/murmurhash3.c"]}
 ]
 
+[tool.setuptools.packages.find]
+where = ["src/mmh3"]
+
+[tool.setuptools.package-data]
+mmh3 = ["murmurhash3.h", "hashlib.h"]
+
 [tool.pylint]
 ignore-paths = [
   "^build",


### PR DESCRIPTION
This PR fixes the issue reported in #90 that the package could not be built from the source distribution (`sdist`). It also adds tests to verify building from the source distribution, ensuring this issue does not recur.

The PR also includes a few minor documentation fixes and enhancements.