### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-14, windows-2022, ubuntu-22.04]
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.9, "3.10", "3.11", "3.12"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -52,13 +52,12 @@ jobs:
         with:
           output-dir: wheelhouse
         env:
-          CIBW_BUILD: "{cp38,cp39,cp310,cp311,cp312,cp313}-${{ matrix.build }}*"
-          CIBW_SKIP: cp38-win_arm64
+          CIBW_BUILD: "{cp39,cp310,cp311,cp312,cp313}-${{ matrix.build }}*"
           CIBW_ARCHS: ${{ matrix.archs }}
           CIBW_BUILD_FRONTEND: "build"
           CIBW_TEST_REQUIRES: "pytest"
           CIBW_TEST_COMMAND: "pytest {project}"
-          CIBW_TEST_SKIP: "*-win_arm64 cp38-macosx_*:arm64"
+          CIBW_TEST_SKIP: "*-win_arm64"
       - uses: actions/upload-artifact@v4
         with:
           name: Wheel-${{ matrix.os }}-${{ matrix.build }}${{ matrix.archs }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ since version 3.0.0.
 ### Added
 
 - Improve the performance of `hash128()`, `hash64()`, and `hash_bytes()`
-  by using METH_FASTCALL, reducing the overhead of function calls.
+  by using METH_FASTCALL, reducing the overhead of function calls
+  ([#116](https://github.com/hajimes/mmh3/pull/116)).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ since version 3.0.0.
 - Improve the performance of `hash128()`, `hash64()`, and `hash_bytes()`
   by using METH_FASTCALL, reducing the overhead of function calls.
 
+### Removed
+
+- Drop support for Python 3.8, as it has reached the end of life on 2024-10-07.
+
 ## [5.0.1] - 2024-09-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # mmh3
 
-[![Documentation Status](https://readthedocs.org/projects/mmh3/badge/?version=stable)](https://mmh3.readthedocs.io/en/latest/?badge=stable)
+[![Documentation Status](https://readthedocs.org/projects/mmh3/badge/?version=stable)](https://mmh3.readthedocs.io/en/stable/)
 [![GitHub Super-Linter](https://github.com/hajimes/mmh3/actions/workflows/superlinter.yml/badge.svg?branch=master)](https://github.com/hajimes/mmh3/actions?query=workflow%3ASuper-Linter+branch%3Amaster)
 [![Build](https://github.com/hajimes/mmh3/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/hajimes/mmh3/actions/workflows/build.yml?branch=master)
 [![PyPi Version](https://img.shields.io/pypi/v/mmh3.svg?style=flat-square&logo=pypi&logoColor=white)](https://pypi.org/project/mmh3/)
 [![Python Versions](https://img.shields.io/pypi/pyversions/mmh3.svg)](https://pypi.org/project/mmh3/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/license/mit/)
-[![Total Downloads](https://static.pepy.tech/badge/mmh3)](https://www.pepy.tech/projects/mmh3?versions=*&versions=5.*&versions=4.*&versions=3.*&versions=2.*)
-[![Recent Downloads](https://static.pepy.tech/badge/mmh3/month)](https://www.pepy.tech/projects/mmh3?versions=*&versions=5.*&versions=4.*&versions=3.*&versions=2.*)
+[![Total Downloads](https://static.pepy.tech/badge/mmh3)](https://pepy.tech/projects/mmh3?versions=*%2C5.*%2C4.*%2C3.*%2C2.*)
+[![Recent Downloads](https://static.pepy.tech/badge/mmh3/month)](https://pepy.tech/projects/mmh3?versions=*%2C5.*%2C4.*%2C3.*%2C2.*)
 
 `mmh3` is a Python extension for
 [MurmurHash (MurmurHash3)](https://en.wikipedia.org/wiki/MurmurHash), a set of
@@ -85,7 +85,12 @@ complete changelog.
 #### Added
 
 - Improve the performance of `hash128()`, `hash64()`, and `hash_bytes()`
-  by using METH_FASTCALL, reducing the overhead of function calls.
+  by using METH_FASTCALL, reducing the overhead of function calls
+  ([#116](https://github.com/hajimes/mmh3/pull/116)).
+
+#### Removed
+
+- Drop support for Python 3.8, as it has reached the end of life on 2024-10-07.
 
 ### [5.0.1] - 2024-09-22
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description = "Python extension for MurmurHash (MurmurHash3), a set of fast and 
 readme = "README.md"
 license = {file = "LICENSE"}
 keywords = ["utility", "hash", "MurmurHash"]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
   {name = "Hajime Senuma", email="hajime.senuma@gmail.com"}
 ]
@@ -19,7 +19,6 @@ classifiers = [
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/src/mmh3/__init__.pyi
+++ b/src/mmh3/__init__.pyi
@@ -1,6 +1,3 @@
-# to use list, tuple, dict ... in Python 3.7 and 3.8
-from __future__ import annotations
-
 import sys
 from typing import Any, Union, final
 

--- a/util/refresh.py
+++ b/util/refresh.py
@@ -1,6 +1,9 @@
 # pylint: disable=missing-function-docstring
 """A script to generate Murmurhash3 C files from the original C++ source."""
 
+# For forward references
+from __future__ import annotations
+
 import os
 import re
 import textwrap

--- a/util/refresh.py
+++ b/util/refresh.py
@@ -1,8 +1,6 @@
 # pylint: disable=missing-function-docstring
 """A script to generate Murmurhash3 C files from the original C++ source."""
 
-from __future__ import annotations
-
 import os
 import re
 import textwrap
@@ -656,9 +654,11 @@ if __name__ == "__main__":
     new_header_path = os.path.join(dir_path, "../src/mmh3", NEW_HEADER_NAME)
     file_header_path = os.path.join(dir_path, FILE_HEADER_NAME)
 
-    with open(original_source_path, "r", encoding="utf-8") as source_file, open(
-        original_header_path, "r", encoding="utf-8"
-    ) as header_file, open(file_header_path, "r", encoding="utf-8") as file_header_file:
+    with (
+        open(original_source_path, "r", encoding="utf-8") as source_file,
+        open(original_header_path, "r", encoding="utf-8") as header_file,
+        open(file_header_path, "r", encoding="utf-8") as file_header_file,
+    ):
         source = MMH3Source(source_file.read())
         header = MMH3Header(header_file.read())
         file_header = file_header_file.read()


### PR DESCRIPTION
Drop support for Python 3.8, as it has reached the end of life on 2024-10-07.