### PR TITLE
Feature/mobile os

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,34 +17,41 @@ permissions: {}
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}_${{ matrix.archs }}
+    name: Build wheel for ${{ matrix.platform }}-${{ matrix.archs }} (runs on ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-24.04]
+        platform: linux
         archs: [x86_64, i686, aarch64, ppc64le, s390x]
         build: [manylinux, musllinux]
         include:
           - os: windows-2022
+            platform: windows
             archs: AMD64
           - os: windows-2022
+            platform: windows
             archs: x86
           - os: windows-2022
+            platform: windows
             archs: ARM64
           - os: macos-13
+            platform: macos
             archs: x86_64
           - os: macos-14
+            platform: macos
             archs: arm64
           - os: macos-14
+            platform: macos
             archs: universal2
-          - platform: ios
-            os: macos-14
+          - os: macos-14
+            platform: ios
             archs: arm64_iphoneos
-          - platform: ios
-            os: macos-14
+          - os: macos-14
+            platform: ios
             archs: arm64_iphonesimulator
-          - platform: ios
-            os: macos-13
+          - os: macos-13
+            platform: ios
             archs: x86_64_iphonesimulator
     steps:
       - name: Checkout
@@ -62,6 +69,7 @@ jobs:
           output-dir: wheelhouse
         env:
           CIBW_BUILD: "{cp39,cp310,cp311,cp312,cp313}-${{ matrix.build }}*"
+          CIBW_PLATFORM: ${{ matrix.platform }}
           CIBW_ARCHS: ${{ matrix.archs }}
           CIBW_BUILD_FRONTEND: "build"
           CIBW_TEST_REQUIRES: "pytest"
@@ -69,7 +77,7 @@ jobs:
           CIBW_TEST_SKIP: "*-win_arm64"
       - uses: actions/upload-artifact@v4
         with:
-          name: Wheel-${{ matrix.os }}-${{ matrix.build }}${{ matrix.archs }}
+          name: Wheel-${{ matrix.os }}-${{ matrix.platform }}-${{ matrix.build }}${{ matrix.archs }}
           path: ./wheelhouse/*.whl
   build_sdist:
     name: Build a source distribution

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,6 +37,12 @@ jobs:
             archs: arm64
           - os: macos-14
             archs: universal2
+          - os: macos-13
+            archs: x86_64_iphonesimulator
+          - os: macos-14
+            archs: arm64_iphonesimulator
+          - os: macos-14
+            archs: arm64_iphoneos
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -52,7 +58,7 @@ jobs:
         with:
           output-dir: wheelhouse
         env:
-          CIBW_BUILD: "{cp39,cp310,cp311,cp312,cp313,cp314}-${{ matrix.build }}* cp313-{arm64_iphoneos,arm64_iphonesimulator,x86_64_iphonesimulator}"
+          CIBW_BUILD: "{cp39,cp310,cp311,cp312,cp313}-${{ matrix.build }}*"
           CIBW_ARCHS: ${{ matrix.archs }}
           CIBW_BUILD_FRONTEND: "build"
           CIBW_TEST_REQUIRES: "pytest"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,14 +37,14 @@ jobs:
             archs: arm64
           - os: macos-14
             archs: universal2
-          - os: macos-14
-            platform: ios
+          - platform: ios
+            sos: macos-14
             archs: arm64_iphoneos
-          - os: macos-14
-            platform: ios
+          - platform: ios
+            os: macos-14
             archs: arm64_iphonesimulator
-          - os: macos-13
-            platform: ios
+          - platform: ios
+            os: macos-13
             archs: x86_64_iphonesimulator
     steps:
       - name: Checkout

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,6 +37,12 @@ jobs:
             archs: arm64
           - os: macos-14
             archs: universal2
+          - os: ubuntu-24.04
+            platform: android
+            archs: arm64_v8a
+          - os: ubuntu-24.04
+            platform: android
+            archs: arm64_x86_64
           - os: macos-14
             platform: ios
             archs: arm64_iphoneos
@@ -66,8 +72,10 @@ jobs:
           CIBW_ARCHS: ${{ matrix.archs }}
           CIBW_BUILD_FRONTEND: "build"
           CIBW_TEST_REQUIRES: "pytest"
+          CIBW_TEST_SOURCES_ANDROID: "./tests"
           CIBW_TEST_SOURCES_IOS: "./tests"
           CIBW_TEST_COMMAND: "pytest {project}"
+          CIBW_TEST_ANDROID_IOS: "python -m pytest ./tests"
           CIBW_TEST_COMMAND_IOS: "python -m pytest ./tests"
           CIBW_TEST_SKIP: "*-win_arm64"
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -40,9 +40,11 @@ jobs:
           - os: ubuntu-24.04
             platform: android
             archs: arm64_v8a
+            build: android
           - os: ubuntu-24.04
             platform: android
             archs: x86_64
+            build: android
           - os: macos-14
             platform: ios
             archs: arm64_iphoneos
@@ -75,7 +77,7 @@ jobs:
           CIBW_TEST_SOURCES_ANDROID: "./tests"
           CIBW_TEST_SOURCES_IOS: "./tests"
           CIBW_TEST_COMMAND: "pytest {project}"
-          CIBW_TEST_ANDROID_IOS: "python -m pytest ./tests"
+          CIBW_TEST_COMMAND_ANDROID: "python -m pytest ./tests"
           CIBW_TEST_COMMAND_IOS: "python -m pytest ./tests"
           CIBW_TEST_SKIP: "*-win_arm64"
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -39,11 +39,11 @@ jobs:
             archs: universal2
           - os: ubuntu-24.04
             platform: android
-            archs: arm64_v8a
-            build: android
-          - os: ubuntu-24.04
-            platform: android
             archs: x86_64
+            build: android
+          - os: macos-14
+            platform: android
+            archs: arm64_v8a
             build: android
           - os: macos-14
             platform: ios

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -38,7 +38,7 @@ jobs:
           - os: macos-14
             archs: universal2
           - platform: ios
-            sos: macos-14
+            os: macos-14
             archs: arm64_iphoneos
           - platform: ios
             os: macos-14

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -62,8 +62,15 @@ jobs:
         with:
           python-version: "3.13"
       - name: Set up QEMU
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.platform != 'android'
         uses: docker/setup-qemu-action@v3
+      # https://github.blog/changelog/2024-04-02-github-actions-hardware-accelerated-android-virtualization-now-available/
+      - name: Set up KVM for Android emulation
+        if: runner.os == 'Linux' && matrix.platform == 'android'
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.1
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,12 +17,11 @@ permissions: {}
 
 jobs:
   build_wheels:
-    name: Build wheel for ${{ matrix.platform }}-${{ matrix.archs }} (runs on ${{ matrix.os }})
+    name: Build wheel for ${{ matrix.archs }} (runs on ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-24.04]
-        platform: linux
         archs: [x86_64, i686, aarch64, ppc64le, s390x]
         build: [manylinux, musllinux]
         include:
@@ -69,7 +68,7 @@ jobs:
           output-dir: wheelhouse
         env:
           CIBW_BUILD: "{cp39,cp310,cp311,cp312,cp313}-${{ matrix.build }}*"
-          CIBW_PLATFORM: ${{ matrix.platform }}
+          CIBW_PLATFORM: ${{ matrix.platform || 'auto' }}
           CIBW_ARCHS: ${{ matrix.archs }}
           CIBW_BUILD_FRONTEND: "build"
           CIBW_TEST_REQUIRES: "pytest"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -72,7 +72,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.archs }}
           CIBW_BUILD_FRONTEND: "build"
           CIBW_TEST_REQUIRES: "pytest"
-          CIBW_TEST_COMMAND: "pytest {project}"
+          CIBW_TEST_COMMAND: "python -m pytest"
           CIBW_TEST_SKIP: "*-win_arm64"
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,14 +37,7 @@ jobs:
             archs: arm64
           - os: macos-14
             archs: universal2
-          - os: macos-13
-            build: ios
-            archs: x86_64_iphonesimulator
-          - os: macos-14
-            build: ios
-            archs: arm64_iphonesimulator
-          - os: macos-14
-            build: ios
+          - os: ios
             archs: arm64_iphoneos
     steps:
       - name: Checkout

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,7 +17,7 @@ permissions: {}
 
 jobs:
   build_wheels:
-    name: Build wheel for ${{ matrix.archs }} ${{ matrix.build }} (runs on ${{ matrix.os }})
+    name: Build wheel for ${{ matrix.platform }} ${{ matrix.archs }} ${{ matrix.build }} (runs on ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -42,7 +42,7 @@ jobs:
             archs: arm64_v8a
           - os: ubuntu-24.04
             platform: android
-            archs: arm64_x86_64
+            archs: x86_64
           - os: macos-14
             platform: ios
             archs: arm64_iphoneos

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -46,15 +46,12 @@ jobs:
           - os: macos-14
             platform: ios
             archs: arm64_iphoneos
-            test-command: python -m pytest ./tests
           - os: macos-14
             platform: ios
             archs: arm64_iphonesimulator
-            test-command: python -m pytest ./tests
           - os: macos-13
             platform: ios
             archs: x86_64_iphonesimulator
-            test-command: python -m pytest ./tests
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -75,7 +72,9 @@ jobs:
           CIBW_ARCHS: ${{ matrix.archs }}
           CIBW_BUILD_FRONTEND: "build"
           CIBW_TEST_REQUIRES: "pytest"
-          CIBW_TEST_COMMAND: ${{matrix.test-command || 'pytest {project}'}}
+          CIBW_TEST_SOURCES_IOS: "./tests"
+          CIBW_TEST_COMMAND: "pytest {project}"
+          CIBW_TEST_COMMAND_IOS: "python -m pytest ./tests"
           CIBW_TEST_SKIP: "*-win_arm64"
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           output-dir: wheelhouse
         env:
-          CIBW_BUILD: "{cp39,cp310,cp311,cp312,cp313,cp314}-${{ matrix.build }}*"
+          CIBW_BUILD: "{cp39,cp310,cp311,cp312,cp313,cp314}-${{ matrix.build }}* cp313-{arm64_iphoneos,arm64_iphonesimulator,x86_64_iphonesimulator}"
           CIBW_ARCHS: ${{ matrix.archs }}
           CIBW_BUILD_FRONTEND: "build"
           CIBW_TEST_REQUIRES: "pytest"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -46,15 +46,15 @@ jobs:
           - os: macos-14
             platform: ios
             archs: arm64_iphoneos
-            test-command: python -m pytest
+            test-command: python -m pytest ./tests
           - os: macos-14
             platform: ios
             archs: arm64_iphonesimulator
-            test-command: python -m pytest
+            test-command: python -m pytest ./tests
           - os: macos-13
             platform: ios
             archs: x86_64_iphonesimulator
-            test-command: python -m pytest
+            test-command: python -m pytest ./tests
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -86,7 +86,7 @@ jobs:
           CIBW_TEST_COMMAND: "pytest {project}"
           CIBW_TEST_COMMAND_ANDROID: "python -m pytest ./tests"
           CIBW_TEST_COMMAND_IOS: "python -m pytest ./tests"
-          CIBW_TEST_SKIP: "*-win_arm64"
+          CIBW_TEST_SKIP: "*-win_arm64 *-android_arm64_v8a"
       - uses: actions/upload-artifact@v4
         with:
           name: Wheel-${{ matrix.os }}-${{ matrix.platform }}-${{ matrix.build }}${{ matrix.archs }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,7 +17,7 @@ permissions: {}
 
 jobs:
   build_wheels:
-    name: Build wheel for ${{ matrix.archs }} (runs on ${{ matrix.os }})
+    name: Build wheel for ${{ matrix.archs }} ${{ matrix.build }} (runs on ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -26,22 +26,16 @@ jobs:
         build: [manylinux, musllinux]
         include:
           - os: windows-2022
-            platform: windows
             archs: AMD64
           - os: windows-2022
-            platform: windows
             archs: x86
           - os: windows-2022
-            platform: windows
             archs: ARM64
           - os: macos-13
-            platform: macos
             archs: x86_64
           - os: macos-14
-            platform: macos
             archs: arm64
           - os: macos-14
-            platform: macos
             archs: universal2
           - os: macos-14
             platform: ios
@@ -67,7 +61,7 @@ jobs:
         with:
           output-dir: wheelhouse
         env:
-          CIBW_BUILD: "{cp39,cp310,cp311,cp312,cp313}-${{ matrix.build }}*"
+          CIBW_BUILD: "{cp39,cp310,cp311,cp312,cp313,cp314}-${{ matrix.build }}*"
           CIBW_PLATFORM: ${{ matrix.platform || 'auto' }}
           CIBW_ARCHS: ${{ matrix.archs }}
           CIBW_BUILD_FRONTEND: "build"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -38,10 +38,13 @@ jobs:
           - os: macos-14
             archs: universal2
           - os: macos-13
+            build: ios
             archs: x86_64_iphonesimulator
           - os: macos-14
+            build: ios
             archs: arm64_iphonesimulator
           - os: macos-14
+            build: ios
             archs: arm64_iphoneos
     steps:
       - name: Checkout

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -46,12 +46,15 @@ jobs:
           - os: macos-14
             platform: ios
             archs: arm64_iphoneos
+            test-command: python -m pytest
           - os: macos-14
             platform: ios
             archs: arm64_iphonesimulator
+            test-command: python -m pytest
           - os: macos-13
             platform: ios
             archs: x86_64_iphonesimulator
+            test-command: python -m pytest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -72,7 +75,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.archs }}
           CIBW_BUILD_FRONTEND: "build"
           CIBW_TEST_REQUIRES: "pytest"
-          CIBW_TEST_COMMAND: "python -m pytest"
+          CIBW_TEST_COMMAND: ${{matrix.test-command || 'pytest {project}'}}
           CIBW_TEST_SKIP: "*-win_arm64"
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,8 +37,15 @@ jobs:
             archs: arm64
           - os: macos-14
             archs: universal2
-          - os: ios
+          - os: macos-14
+            platform: ios
             archs: arm64_iphoneos
+          - os: macos-14
+            platform: ios
+            archs: arm64_iphonesimulator
+          - os: macos-13
+            platform: ios
+            archs: x86_64_iphonesimulator
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ This project has adhered to
 [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html)
 since version 3.0.0.
 
+## [Unreleased]
+
+### Added
+
+- Add support for Python 3.14.
+- Add support for Android (Python 3.13 only) and iOS (Python 3.13 and 3.14) wheels,
+  enabled by the major version update of
+  [cibuildwheel](https://github.com/pypa/cibuildwheel).
+
 ## [5.1.0] - 2025-01-25
 
 ### Added
@@ -287,6 +296,7 @@ only.
   [Softpedia collected mmh3 1.0 on April 27, 2011](https://web.archive.org/web/20110430172027/https://linux.softpedia.com/get/Programming/Libraries/mmh3-68314.shtml),
   it must have been uploaded to PyPI on or slightly before this date.
 
+[unreleased]: https://github.com/hajimes/mmh3/compare/v5.1.0...HEAD
 [5.1.0]: https://github.com/hajimes/mmh3/compare/v5.0.1...v5.1.0
 [5.0.1]: https://github.com/hajimes/mmh3/compare/v5.0.0...v5.0.1
 [5.0.0]: https://github.com/hajimes/mmh3/compare/v4.1.0...v5.0.0

--- a/README.md
+++ b/README.md
@@ -78,12 +78,11 @@ in the API Reference for more information.
 
 ## Changelog
 
-See [Changelog](https://mmh3.readthedocs.io/en/latest/changelog.html)
-(latest version) for the complete changelog.
+See [Changelog (latest version)](https://mmh3.readthedocs.io/en/latest/changelog.html) for the complete changelog.
 
-## [Unreleased]
+### [Unreleased]
 
-### Added
+#### Added
 
 - Add support for Python 3.14.
 - Add support for Android (Python 3.13 only) and iOS (Python 3.13 and 3.14) wheels,

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ in the API Reference for more information.
 
 ## Changelog
 
-See [Changelog (latest version)](https://mmh3.readthedocs.io/en/latest/changelog.html) for the complete changelog.
+See [Changelog (latest version)](https://mmh3.readthedocs.io/en/latest/changelog.html)
+for the complete changelog.
 
 ### [Unreleased]
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ in the API Reference for more information.
 See [Changelog](https://mmh3.readthedocs.io/en/latest/changelog.html)
 (latest version) for the complete changelog.
 
+## [Unreleased]
+
+### Added
+
+- Add support for Python 3.14.
+- Add support for Android (Python 3.13 only) and iOS (Python 3.13 and 3.14) wheels,
+  enabled by the major version update of
+  [cibuildwheel](https://github.com/pypa/cibuildwheel).
+
 ### [5.1.0] - 2025-01-25
 
 #### Added
@@ -107,57 +116,6 @@ See [Changelog](https://mmh3.readthedocs.io/en/latest/changelog.html)
 
 - Fix the issue that the package cannot be built from the source distribution
   ([#90](https://github.com/hajimes/mmh3/issues/90)).
-
-### [5.0.0] - 2024-09-18
-
-#### Added
-
-- Add support for Python 3.13.
-- Improve the performance of the `hash()` function with
-  [METH_FASTCALL](https://docs.python.org/3/c-api/structures.html#c.METH_FASTCALL),
-  reducing the overhead of function calls. For data sizes between 1–2 KB
-  (e.g., 48x48 favicons), performance is 10%–20% faster. For smaller data
-  (~500 bytes, like 16x16 favicons), performance increases by approximately 30%
-  ([#87](https://github.com/hajimes/mmh3/pull/87)).
-- Add `digest` functions that support the new buffer protocol
-  ([PEP 688](https://peps.python.org/pep-0688/)) as input
-  ([#75](https://github.com/hajimes/mmh3/pull/75)).
-  These functions are implemented with `METH_FASTCALL` too, offering improved
-  performance ([#84](https://github.com/hajimes/mmh3/pull/84)).
-- Slightly improve the performance of the `hash_bytes()` function
-  ([#88](https://github.com/hajimes/mmh3/pull/88))
-- Add Read the Docs documentation
-  ([#54](https://github.com/hajimes/mmh3/issues/54)).
-- Document benchmark results
-  ([#53](https://github.com/hajimes/mmh3/issues/53)).
-
-#### Changed
-
-- **Backward-incompatible**: The `seed` argument is now strictly validated to
-  ensure it falls within the range [0, 0xFFFFFFFF]. A `ValueError` is raised
-  if the seed is out of range ([#84](https://github.com/hajimes/mmh3/pull/84)).
-- **Backward-incompatible**: Change the constructors of hasher classes to
-  accept a buffer as the first argument
-  ([#83](https://github.com/hajimes/mmh3/pull/83)).
-- The type of flag argumens has been changed from `bool` to `Any`
-  ([#84](https://github.com/hajimes/mmh3/pull/84)).
-- Change the format of CHANGELOG.md to conform to the
-  [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) standard
-  ([#63](https://github.com/hajimes/mmh3/pull/63)).
-
-#### Deprecated
-
-- Deprecate the `hash_from_buffer()` function.
-  Use `mmh3_32_sintdigest()` or `mmh3_32_uintdigest()` as alternatives
-  ([#84](https://github.com/hajimes/mmh3/pull/84)).
-
-#### Fixed
-
-- Fix a reference leak in the `hash_from_buffer()` function
-  ([#75](https://github.com/hajimes/mmh3/pull/75)).
-- Fix type hints ([#76](https://github.com/hajimes/mmh3/pull/76),
-  [#77](https://github.com/hajimes/mmh3/pull/77),
-  [#84](https://github.com/hajimes/mmh3/pull/84)).
 
 ## License
 
@@ -305,6 +263,6 @@ In BibTeX format:
 - <https://github.com/ifduyue/python-xxhash>: Python bindings for xxHash (Yue
   Du)
 
+[unreleased]: https://github.com/hajimes/mmh3/compare/v5.1.0...HEAD
 [5.1.0]: https://github.com/hajimes/mmh3/compare/v5.0.1...v5.1.0
 [5.0.1]: https://github.com/hajimes/mmh3/compare/v5.0.0...v5.0.1
-[5.0.0]: https://github.com/hajimes/mmh3/compare/v4.1.0...v5.0.0


### PR DESCRIPTION
This PR adds support for Android / iOS wheels, thanks to the excellent updates of cibuildwheel 3.0.0 and 3.1.0 (specifically, [PR #2349](https://github.com/pypa/cibuildwheel/pull/2349) for Android and [PR 2286](https://github.com/pypa/cibuildwheel/pull/2286) for iOS).

Updating the GitHub Actions workflow to accommodate these platforms was a bit challenging, so I'm sharing my experience here. I hope it may help other engineers in the future, when they face similar issues. My own code is available at https://github.com/hajimes/mmh3/blob/master/.github/workflows/wheels.yml.

1. **Start with the official documentation**
   See the cibuildwheel platforms and options guides:
   * [https://cibuildwheel.pypa.io/en/stable/platforms/](https://cibuildwheel.pypa.io/en/stable/platforms/)
   * [https://cibuildwheel.pypa.io/en/stable/options/](https://cibuildwheel.pypa.io/en/stable/options/)

   Also, consult their YAML example:
   * [https://github.com/pypa/cibuildwheel/blob/main/examples/github-deploy.yml](https://github.com/pypa/cibuildwheel/blob/main/examples/github-deploy.yml)
2. **Explicitly declare `platform` (usually in the build matrix)**
   For standard platforms (`linux`, `windows`, `macos`), `cibuildwheel` infers this automatically. But for `android` and `ios`, you must declare it manually. Then, set `CIBW_PLATFORM: ${{ matrix.platform || 'auto' }}` to ensure proper platform selection. This instructs cibuildwheel to use the `platform` value specified in the build matrix when available; otherwise, it falls back to the runner's OS.
3. **Configure Android/iOS-specific environment variables for testing**
   For example, if using `pytest` and your tests are under `./tests`, define:
   ```yaml
   CIBW_TEST_SOURCES_ANDROID: "./tests"
   CIBW_TEST_SOURCES_IOS: "./tests"
   CIBW_TEST_COMMAND_ANDROID: "python -m pytest ./tests"
   CIBW_TEST_COMMAND_IOS: "python -m pytest ./tests"
   ```
   Standard platforms usually use `pytest {project}` as the testing command with cibuildwheel. However, Android/iOS builds cannot resolve the `{project}` placeholder, so explicit paths are required. Also note: `CIBW_TEST_SOURCES_*` must be defined, even if test file paths are stated within `CIBW_TEST_COMMAND_*`.
4. **For Android-Intel builds (that is, `*-android_x86_64`), use a Linux runner (e.g., `ubuntu-latest`) and enable the kernel-based virtual machine (KVM) for testing**.
   If you don't specify this, testing will fail (as of cibuildwheel 3.1.1). You can just copy and paste the code from https://github.blog/changelog/2024-04-02-github-actions-hardware-accelerated-android-virtualization-now-available/. Also, see https://github.com/pypa/cibuildwheel/blob/v3.1.1/examples/github-deploy.yml#L55-L61 for the real-world example.
5. **For Android-ARM builds (that is, `*-android_arm64_v8a`), the canonical approach is to use an Apple Silicon runner (e.g., `macos-latest`) and skip testing**.
   As of cibuildwheel 3.1.1, macOS runners on GitHub Actions do not support testing under Android emulation. Therefore, you must explicitly skip tests using `CIBW_TEST_SKIP: "-android_arm64_v8a"`. Alternatively, you can build on Intel Linux (e.g., `ubuntu-latest`), where tests are automatically skipped due to emulator limitations (no need to set `CIBW_TEST_SKIP`). This results in one fewer configuration line. However, from a code maintanability perspective, I recommend using `macos` for future extensions and support.
6. **For iOS builds,**
   Use:
	* `macos-13` (Intel Mac runner) for `x86_64_iphonesimulator`
	* `macos-14`or `macos-latest` (Apple Silicon runners) for `arm64_iphoneos` and `arm64_iphonesimulator` architectures