### PR TITLE
Release v5.2.2 with Windows ARM64 wheel support

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -25,6 +25,8 @@ jobs:
             archs: x86
           - os: windows-2025
             archs: ARM64
+          - os: windows-11-arm
+            archs: ARM64
           - os: macos-26-intel
             archs: x86_64
           - os: macos-26
@@ -101,7 +103,7 @@ jobs:
           CIBW_TEST_COMMAND: "pytest {project}"
           CIBW_TEST_COMMAND_ANDROID: "python -m pytest ./tests"
           CIBW_TEST_COMMAND_IOS: "python -m pytest ./tests"
-          CIBW_TEST_SKIP: "*-win_arm64 *-android_arm64_v8a"
+          CIBW_TEST_SKIP: "*-android_arm64_v8a"
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: Wheel-${{ matrix.os }}-${{ matrix.platform }}-${{ matrix.build }}${{ matrix.archs }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,16 @@ contributors, see the
 [Contributors](https://mmh3.readthedocs.io/en/stable/CONTRIBUTORS.html) page.
 
 The format is based on
-[Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/).
+[Keep a Changelog 2.0.0](https://keepachangelog.com/en/2.0.0/).
 This project has adhered to
 [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html)
 since version 3.0.0.
+
+## [5.2.2] - 2026-07-31
+
+### Added
+
+- Add support for Windows ARM64 wheels.
 
 ## [5.2.1] - 2026-03-06
 
@@ -310,6 +316,7 @@ only.
   [Softpedia collected mmh3 1.0 on April 27, 2011](https://web.archive.org/web/20110430172027/https://linux.softpedia.com/get/Programming/Libraries/mmh3-68314.shtml),
   it must have been uploaded to PyPI on or slightly before this date.
 
+[5.2.2]: https://github.com/hajimes/mmh3/compare/v5.2.1...v5.2.2
 [5.2.1]: https://github.com/hajimes/mmh3/compare/v5.2.0...v5.2.1
 [5.2.0]: https://github.com/hajimes/mmh3/compare/v5.1.0...v5.2.0
 [5.1.0]: https://github.com/hajimes/mmh3/compare/v5.0.1...v5.1.0

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ in the API Reference for more information.
 See [Changelog (latest version)](https://mmh3.readthedocs.io/en/latest/changelog.html)
 for the complete changelog.
 
+### [5.2.2] - 2026-07-31
+
+#### Added
+
+- Add support for Windows ARM64 wheels.
+
 ### [5.2.1] - 2026-03-06
 
 #### Added
@@ -103,26 +109,6 @@ for the complete changelog.
   enabled by the major version update of
   [cibuildwheel](https://github.com/pypa/cibuildwheel)
   ([#135](https://github.com/hajimes/mmh3/pull/135)).
-
-### [5.1.0] - 2025-01-25
-
-#### Added
-
-- Improve the performance of `hash128()`, `hash64()`, and `hash_bytes()` by
-  using
-  [METH_FASTCALL](https://docs.python.org/3/c-api/structures.html#c.METH_FASTCALL),
-  reducing the overhead of function calls
-  ([#116](https://github.com/hajimes/mmh3/pull/116)).
-- Add the software paper for this library
-  ([doi:10.21105/joss.06124](https://doi.org/10.21105/joss.06124)), following
-  its publication in the
-  [_Journal of Open Source Software_](https://joss.theoj.org)
-  ([#118](https://github.com/hajimes/mmh3/pull/118)).
-
-#### Removed
-
-- Drop support for Python 3.8, as it has reached the end of life on 2024-10-07
-  ([#117](https://github.com/hajimes/mmh3/pull/117)).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,6 @@ In BibTeX format:
 - <https://github.com/ifduyue/python-xxhash>: Python bindings for xxHash (Yue
   Du)
 
+[5.2.2]: https://github.com/hajimes/mmh3/compare/v5.2.1...v5.2.2
 [5.2.1]: https://github.com/hajimes/mmh3/compare/v5.2.0...v5.2.1
 [5.2.0]: https://github.com/hajimes/mmh3/compare/v5.1.0...v5.2.0
-[5.1.0]: https://github.com/hajimes/mmh3/compare/v5.0.1...v5.1.0

--- a/docs/CONTRIBUTORS.md
+++ b/docs/CONTRIBUTORS.md
@@ -28,6 +28,8 @@ We gratefully acknowledge the contributions of the following individuals:
   [#37](https://github.com/hajimes/mmh3/pull/37).
 - [Matthew Honnibal](https://github.com/honnibal),
   [#22](https://github.com/hajimes/mmh3/pull/22).
+- [MUGUNDAN](https://github.com/MugundanMCW),
+  [#175](https://github.com/hajimes/mmh3/pull/175).
 - [wouter bolsterlee](https://github.com/wbolster),
   [#35](https://github.com/hajimes/mmh3/pull/35).
 


### PR DESCRIPTION
This PR prepares the v5.2.2 release and incorporates the changes from #175.