### PR TITLE
Do not write into const-qualified digest buffers

### DIFF
--- a/src/mmh3/mmh3module.c
+++ b/src/mmh3/mmh3module.c
@@ -1765,7 +1765,7 @@ MMH3Hasher128x64_update(MMH3Hasher128x64 *self, PyObject *obj)
 static PyObject *
 MMH3Hasher128x64_digest(MMH3Hasher128x64 *self, PyObject *Py_UNUSED(ignored))
 {
-    const char out[MMH3_128_DIGESTSIZE];
+    char out[MMH3_128_DIGESTSIZE];
     MMH3_HASHER_LOCK(self);
     digest_x64_128_impl(self->h1, self->h2, self->buffer1, self->buffer2,
                         self->length, out);
@@ -1777,7 +1777,7 @@ static PyObject *
 MMH3Hasher128x64_sintdigest(MMH3Hasher128x64 *self,
                             PyObject *Py_UNUSED(ignored))
 {
-    const char out[MMH3_128_DIGESTSIZE];
+    char out[MMH3_128_DIGESTSIZE];
     MMH3_HASHER_LOCK(self);
     digest_x64_128_impl(self->h1, self->h2, self->buffer1, self->buffer2,
                         self->length, out);
@@ -1801,7 +1801,7 @@ static PyObject *
 MMH3Hasher128x64_uintdigest(MMH3Hasher128x64 *self,
                             PyObject *Py_UNUSED(ignored))
 {
-    const char out[MMH3_128_DIGESTSIZE];
+    char out[MMH3_128_DIGESTSIZE];
     MMH3_HASHER_LOCK(self);
     digest_x64_128_impl(self->h1, self->h2, self->buffer1, self->buffer2,
                         self->length, out);
@@ -1834,7 +1834,7 @@ static PyObject *
 MMH3Hasher128x64_stupledigest(MMH3Hasher128x64 *self,
                               PyObject *Py_UNUSED(ignored))
 {
-    const char out[MMH3_128_DIGESTSIZE];
+    char out[MMH3_128_DIGESTSIZE];
     MMH3_HASHER_LOCK(self);
     digest_x64_128_impl(self->h1, self->h2, self->buffer1, self->buffer2,
                         self->length, out);
@@ -1866,7 +1866,7 @@ static PyObject *
 MMH3Hasher128x64_utupledigest(MMH3Hasher128x64 *self,
                               PyObject *Py_UNUSED(ignored))
 {
-    const char out[MMH3_128_DIGESTSIZE];
+    char out[MMH3_128_DIGESTSIZE];
     MMH3_HASHER_LOCK(self);
     digest_x64_128_impl(self->h1, self->h2, self->buffer1, self->buffer2,
                         self->length, out);
@@ -2160,7 +2160,7 @@ static PyObject *
 MMH3Hasher128x86_sintdigest(MMH3Hasher128x86 *self,
                             PyObject *Py_UNUSED(ignored))
 {
-    const char out[MMH3_128_DIGESTSIZE];
+    char out[MMH3_128_DIGESTSIZE];
     MMH3_HASHER_LOCK(self);
     digest_x86_128_impl(self->h1, self->h2, self->h3, self->h4, self->buffer1,
                         self->buffer2, self->buffer3, self->buffer4,
@@ -2185,7 +2185,7 @@ static PyObject *
 MMH3Hasher128x86_uintdigest(MMH3Hasher128x86 *self,
                             PyObject *Py_UNUSED(ignored))
 {
-    const char out[MMH3_128_DIGESTSIZE];
+    char out[MMH3_128_DIGESTSIZE];
     MMH3_HASHER_LOCK(self);
     digest_x86_128_impl(self->h1, self->h2, self->h3, self->h4, self->buffer1,
                         self->buffer2, self->buffer3, self->buffer4,
@@ -2210,7 +2210,7 @@ static PyObject *
 MMH3Hasher128x86_stupledigest(MMH3Hasher128x86 *self,
                               PyObject *Py_UNUSED(ignored))
 {
-    const char out[MMH3_128_DIGESTSIZE];
+    char out[MMH3_128_DIGESTSIZE];
     MMH3_HASHER_LOCK(self);
     digest_x86_128_impl(self->h1, self->h2, self->h3, self->h4, self->buffer1,
                         self->buffer2, self->buffer3, self->buffer4,
@@ -2233,7 +2233,7 @@ static PyObject *
 MMH3Hasher128x86_utupledigest(MMH3Hasher128x86 *self,
                               PyObject *Py_UNUSED(ignored))
 {
-    const char out[MMH3_128_DIGESTSIZE];
+    char out[MMH3_128_DIGESTSIZE];
     MMH3_HASHER_LOCK(self);
     digest_x86_128_impl(self->h1, self->h2, self->h3, self->h4, self->buffer1,
                         self->buffer2, self->buffer3, self->buffer4,

--- a/src/mmh3/murmurhash3.h
+++ b/src/mmh3/murmurhash3.h
@@ -233,7 +233,7 @@ fmix64(uint64_t k)
 
 static FORCE_INLINE void
 digest_x64_128_impl(uint64_t h1, uint64_t h2, const uint64_t k1,
-                    const uint64_t k2, const Py_ssize_t len, const char *out)
+                    const uint64_t k2, const Py_ssize_t len, char *out)
 {
     h1 ^= mixK1_x64_128(k1);
     h2 ^= mixK2_x64_128(k2);
@@ -261,7 +261,7 @@ digest_x64_128_impl(uint64_t h1, uint64_t h2, const uint64_t k1,
 static FORCE_INLINE void
 digest_x86_128_impl(uint32_t h1, uint32_t h2, uint32_t h3, uint32_t h4,
                     const uint32_t k1, const uint32_t k2, const uint32_t k3,
-                    const uint32_t k4, const Py_ssize_t len, const char *out)
+                    const uint32_t k4, const Py_ssize_t len, char *out)
 {
     const uint32_t c1 = 0x239b961b;
     const uint32_t c2 = 0xab0e9789;


### PR DESCRIPTION
The nine 128-bit digest methods declare their output buffer as const and then write into it:

```c
static PyObject *
MMH3Hasher128x64_digest(MMH3Hasher128x64 *self, PyObject *Py_UNUSED(ignored))
{
    const char out[MMH3_128_DIGESTSIZE];
    ...
    digest_x64_128_impl(self->h1, self->h2, self->buffer1, self->buffer2,
                        self->length, out);
```

and in `murmurhash3.h`:

```c
digest_x64_128_impl(..., const char *out)
{
    ...
    ((uint64_t *)out)[0] = h1;
    ((uint64_t *)out)[1] = h2;
}
```

`out` is *defined* with a const-qualified type, so writing to it through a cast is undefined behaviour rather than a style problem - C11 6.7.3p6: "If an attempt is made to modify an object defined with a const-qualified type through use of an lvalue with non-const-qualified type, the behavior is undefined." The implementation is allowed to put such an object in read-only storage, or to assume its contents never change, and the buffer is read straight back by `PyBytes_FromStringAndSize` / `_PyLong_FromByteArray` on the next line.

Casting away const is fine when the underlying object is not itself const, which is why this has worked in practice. The declaration is what makes it UB.

## The change

`const` dropped from the nine buffers in `mmh3module.c` and from the `out` parameter of `digest_x64_128_impl` and `digest_x86_128_impl`. Nothing else touched, no behaviour change intended.

The 32-bit path already gets this right - `MMH3Hasher32_digest` declares `char out[MMH3_32_DIGESTSIZE]` with no const - so this brings the 128-bit ones in line with it rather than inventing a convention.

## Checks

```
$ clang -fsyntax-only -Wcast-qual -I<python-include> src/mmh3/mmh3module.c   # before
18 warnings
$ clang -fsyntax-only -Wcast-qual -I<python-include> src/mmh3/mmh3module.c   # after
0 warnings

$ pip install -e . && pytest tests/ -q
85 passed
```

Found by a `cppcheck --enable=warning` sweep, which reports the buffers as `uninitvar` - it sees a const array that is never initialised and then read. Following that up led to the const-qualification rather than to a genuine uninitialised read.
