### PR TITLE
feat: add Python 3.15 support

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,6 +1,6 @@
-# As of March 5, 2026, actionlint via super-linter 8.5.0 does not support macOS 26, so we ignore the runner-label warning for now.
+# As of August 26, 2026, Actionlint via Super-Linter does not support Ubuntu
+# 26.04, so we ignore this runner-label warning for now.
 paths:
   .github/workflows/**/*.{yml,yaml}:
     ignore:
-      - 'label "macos-26" is unknown.+'
-      - 'label "macos-26-intel" is unknown.+'
+      - 'label "ubuntu-26.04" is unknown.+'

--- a/.github/workflows/benchmark-base-hash.yml
+++ b/.github/workflows/benchmark-base-hash.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     env:
       BENCHMARK_MAX_SIZE: 65536
     steps:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     env:
       BENCHMARK_MAX_SIZE: 262144
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-26, windows-2025, ubuntu-24.04]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,16 @@ jobs:
       matrix:
         os: [macos-26, windows-2025, ubuntu-26.04]
         python-version:
-          ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15-dev", "3.15t-dev"]
+          [
+            "3.10",
+            "3.11",
+            "3.12",
+            "3.13",
+            "3.14",
+            "3.14t",
+            "3.15-dev",
+            "3.15t-dev",
+          ]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,8 @@ jobs:
     strategy:
       matrix:
         os: [macos-26, windows-2025, ubuntu-24.04]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
+        python-version:
+          ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t-dev"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,9 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-26, windows-2025, ubuntu-24.04]
+        os: [macos-26, windows-2025, ubuntu-26.04]
         python-version:
-          ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t-dev"]
+          ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15-dev", "3.15t-dev"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           output-dir: wheelhouse
         env:
-          CIBW_BUILD: "{cp310,cp311,cp312,cp313,cp314,cp314t,cp315,cp315t}-${{ matrix.build }}*"
+          CIBW_BUILD: "{cp310,cp311,cp312,cp313,cp314,cp314t,cp315}-${{ matrix.build }}*"
           CIBW_PLATFORM: ${{ matrix.platform || 'auto' }}
           CIBW_ARCHS: ${{ matrix.archs }}
           CIBW_BUILD_FRONTEND: "build"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -23,7 +23,7 @@ jobs:
             archs: AMD64
           - os: windows-2025
             archs: x86
-          - os: windows-2025
+          - os: windows-11-arm
             archs: ARM64
           - os: macos-26-intel
             archs: x86_64
@@ -101,7 +101,7 @@ jobs:
           CIBW_TEST_COMMAND: "pytest {project}"
           CIBW_TEST_COMMAND_ANDROID: "python -m pytest ./tests"
           CIBW_TEST_COMMAND_IOS: "python -m pytest ./tests"
-          CIBW_TEST_SKIP: "*-win_arm64 *-android_arm64_v8a"
+          CIBW_TEST_SKIP: "*-android_arm64_v8a"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Wheel-${{ matrix.os }}-${{ matrix.platform }}-${{ matrix.build }}${{ matrix.archs }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,7 +31,7 @@ jobs:
             archs: arm64
           - os: macos-26
             archs: universal2
-          - os: ubuntu-26.04
+          - os: ubuntu-24.04
             platform: android
             archs: x86_64
             build: android

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04]
+        os: [ubuntu-26.04]
         archs: [x86_64, i686, aarch64, ppc64le, s390x]
         build: [manylinux, musllinux]
         include:
@@ -31,7 +31,7 @@ jobs:
             archs: arm64
           - os: macos-26
             archs: universal2
-          - os: ubuntu-24.04
+          - os: ubuntu-26.04
             platform: android
             archs: x86_64
             build: android
@@ -108,7 +108,7 @@ jobs:
           path: ./wheelhouse/*.whl
   build_sdist:
     name: Build a source distribution
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -157,7 +157,7 @@ jobs:
     name: "Publish artifacts to PyPI"
     if: startsWith(github.ref, 'refs/tags/')
     needs: [build_wheels, build_sdist]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     environment:
       name: pypi
       url: https://pypi.org/p/mmh3
@@ -175,7 +175,7 @@ jobs:
     name: "Publish artifacts to TestPyPI"
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master'
     needs: [build_wheels, build_sdist]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     environment:
       name: testpypi
       url: https://test.pypi.org/p/mmh3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-26.04]
+        os: [ubuntu-24.04]
         archs: [x86_64, i686, aarch64, ppc64le, s390x]
         build: [manylinux, musllinux]
         include:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           output-dir: wheelhouse
         env:
-          CIBW_BUILD: "{cp310,cp311,cp312,cp313,cp314,cp314t}-${{ matrix.build }}*"
+          CIBW_BUILD: "{cp310,cp311,cp312,cp313,cp314,cp314t,cp315,cp315t}-${{ matrix.build }}*"
           CIBW_PLATFORM: ${{ matrix.platform || 'auto' }}
           CIBW_ARCHS: ${{ matrix.archs }}
           CIBW_BUILD_FRONTEND: "build"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ This project has adhered to
 [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html)
 since version 3.0.0.
 
+## [Unreleased]
+
+### Added
+
+- Add support for Python 3.15, including 3.15t (no-GIL) wheels.
+
 ## [5.2.1] - 2026-03-06
 
 ### Added
@@ -310,6 +316,7 @@ only.
   [Softpedia collected mmh3 1.0 on April 27, 2011](https://web.archive.org/web/20110430172027/https://linux.softpedia.com/get/Programming/Libraries/mmh3-68314.shtml),
   it must have been uploaded to PyPI on or slightly before this date.
 
+[Unreleased]: https://github.com/hajimes/mmh3/compare/v5.2.1...HEAD
 [5.2.1]: https://github.com/hajimes/mmh3/compare/v5.2.0...v5.2.1
 [5.2.0]: https://github.com/hajimes/mmh3/compare/v5.1.0...v5.2.0
 [5.1.0]: https://github.com/hajimes/mmh3/compare/v5.0.1...v5.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ since version 3.0.0.
 
 ### Added
 
-- Add support for Python 3.15, including 3.15t (no-GIL) wheels.
+- Add support for Python 3.15.
 
 ## [5.2.1] - 2026-03-06
 
@@ -287,9 +287,9 @@ Beware that due to this revision, **the result of 32-bit version of 2.1 is NOT
 the same as that of 2.0**. E.g.,:
 
 ```pycon
->>> mmh3.hash("foo") # in mmh3 2.0
+>>> mmh3.hash("foo")  # in mmh3 2.0
 -292180858
->>> mmh3.hash("foo") # in mmh3 2.1
+>>> mmh3.hash("foo")  # in mmh3 2.1
 -156908512
 ```
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ in the API Reference for more information.
 See [Changelog (latest version)](https://mmh3.readthedocs.io/en/latest/changelog.html)
 for the complete changelog.
 
+### [Unreleased]
+
+#### Added
+
+- Add support for Python 3.15, including 3.15t (no-GIL) wheels.
+
 ### [5.2.1] - 2026-03-06
 
 #### Added
@@ -103,26 +109,6 @@ for the complete changelog.
   enabled by the major version update of
   [cibuildwheel](https://github.com/pypa/cibuildwheel)
   ([#135](https://github.com/hajimes/mmh3/pull/135)).
-
-### [5.1.0] - 2025-01-25
-
-#### Added
-
-- Improve the performance of `hash128()`, `hash64()`, and `hash_bytes()` by
-  using
-  [METH_FASTCALL](https://docs.python.org/3/c-api/structures.html#c.METH_FASTCALL),
-  reducing the overhead of function calls
-  ([#116](https://github.com/hajimes/mmh3/pull/116)).
-- Add the software paper for this library
-  ([doi:10.21105/joss.06124](https://doi.org/10.21105/joss.06124)), following
-  its publication in the
-  [_Journal of Open Source Software_](https://joss.theoj.org)
-  ([#118](https://github.com/hajimes/mmh3/pull/118)).
-
-#### Removed
-
-- Drop support for Python 3.8, as it has reached the end of life on 2024-10-07
-  ([#117](https://github.com/hajimes/mmh3/pull/117)).
 
 ## License
 
@@ -270,6 +256,6 @@ In BibTeX format:
 - <https://github.com/ifduyue/python-xxhash>: Python bindings for xxHash (Yue
   Du)
 
+[Unreleased]: https://github.com/hajimes/mmh3/compare/v5.2.1...HEAD
 [5.2.1]: https://github.com/hajimes/mmh3/compare/v5.2.0...v5.2.1
 [5.2.0]: https://github.com/hajimes/mmh3/compare/v5.1.0...v5.2.0
-[5.1.0]: https://github.com/hajimes/mmh3/compare/v5.0.1...v5.1.0

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ pip install mmh3
 
 ```pycon
 >>> import mmh3
->>> mmh3.hash(b"foo") # returns a 32-bit signed int
+>>> mmh3.hash(b"foo")  # returns a 32-bit signed int
 -156908512
->>> mmh3.hash("foo") # accepts str (UTF-8 encoded)
+>>> mmh3.hash("foo")  # accepts str (UTF-8 encoded)
 -156908512
->>> mmh3.hash(b"foo", 42) # uses 42 as the seed
+>>> mmh3.hash(b"foo", 42)  # uses 42 as the seed
 -1322301282
->>> mmh3.hash(b"foo", 0, False) # returns a 32-bit unsigned int
+>>> mmh3.hash(b"foo", 0, False)  # returns a 32-bit unsigned int
 4138058784
 ```
 
@@ -85,7 +85,7 @@ for the complete changelog.
 
 #### Added
 
-- Add support for Python 3.15, including 3.15t (no-GIL) wheels.
+- Add support for Python 3.15.
 
 ### [5.2.1] - 2026-03-06
 
@@ -153,7 +153,7 @@ example:
 >>> mmh3.hash(b"quux", 4294967295)
 258499980
 >>> d = -1
->>> mmh3.hash(b"quux", d & 0xffffffff)
+>>> mmh3.hash(b"quux", d & 0xFFFFFFFF)
 258499980
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -125,17 +125,17 @@ Additionally, `hexdigest()` is not supported; use `digest().hex()` instead.
 
 ```pycon
 >>> import mmh3
->>> hasher = mmh3.mmh3_x64_128(b"foo", 42) # seed=42
+>>> hasher = mmh3.mmh3_x64_128(b"foo", 42)  # seed=42
 >>> hasher.update(b"bar")
 >>> hasher.digest()
 b'\x82_n\xdd \xac\xb6j\xef\x99\xb1e\xc4\n\xc9\xfd'
->>> hasher.sintdigest() # 128 bit signed int
+>>> hasher.sintdigest()  # 128 bit signed int
 -2943813934500665152301506963178627198
->>> hasher.uintdigest() # 128 bit unsigned int
+>>> hasher.uintdigest()  # 128 bit unsigned int
 337338552986437798311073100468589584258
->>> hasher.stupledigest() # two 64 bit signed ints
+>>> hasher.stupledigest()  # two 64 bit signed ints
 (7689522670935629698, -159584473158936081)
->>> hasher.utupledigest() # two 64 bit unsigned ints
+>>> hasher.utupledigest()  # two 64 bit unsigned ints
 (7689522670935629698, 18287159600550615535)
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mmh3"
-version = "5.2.1"
+version = "5.2.2-dev.1"
 description = "Python extension for MurmurHash (MurmurHash3), a set of fast and robust hash functions."
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -24,6 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Programming Language :: Python :: Free Threading :: 2 - Beta",
   "Topic :: Software Development :: Libraries",
   "Topic :: Utilities"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires =
     tox>=4
-envlist = lint, type, py{310,311,312,313,314,314t}
+envlist = lint, type, py{310,311,312,313,314,314t,315,315t}
 
 [testenv]
 description = run unit tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires =
     tox>=4
-envlist = lint, type, py{310,311,312,313,314,314t,315,315t}
+envlist = lint, type, py{310,311,312,313,314,314t,315}
 
 [testenv]
 description = run unit tests


### PR DESCRIPTION
This PR Includes:
- Add Python 3.15 and free-threaded test coverage
- Run Python 3.15 tests against development builds
- Update CI runner labels
- Test Windows ARM64 wheels on a native runner
- Temporarily suppress the Ubuntu 26.04 Actionlint warning