### PR TITLE
ci: build free-threaded Python 3.15 wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           output-dir: wheelhouse
         env:
-          CIBW_BUILD: "{cp310,cp311,cp312,cp313,cp314,cp314t,cp315}-${{ matrix.build }}*"
+          CIBW_BUILD: "{cp310,cp311,cp312,cp313,cp314,cp314t,cp315,cp315t}-${{ matrix.build }}*"
           CIBW_PLATFORM: ${{ matrix.platform || 'auto' }}
           CIBW_ARCHS: ${{ matrix.archs }}
           CIBW_BUILD_FRONTEND: "build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mmh3"
-version = "5.3.0-dev.1"
+version = "5.3.0-dev.2"
 description = "Python extension for MurmurHash (MurmurHash3), a set of fast and robust hash functions."
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
Add cp315t, which was missing from #192.